### PR TITLE
[BUG] missing 2 relative paths

### DIFF
--- a/gossipy/model/sampling.py
+++ b/gossipy/model/sampling.py
@@ -8,7 +8,7 @@ from typing import Dict, Tuple, Optional
 from torch.nn import ParameterList
 
 from .. import LOG
-from gossipy.model.nn import TorchModel
+from .nn import TorchModel
 
 # AUTHORSHIP
 __version__ = "0.0.1"

--- a/gossipy/node.py
+++ b/gossipy/node.py
@@ -5,7 +5,7 @@ from numpy.random import randint, normal, rand
 from numpy import ndarray
 from torch import Tensor
 from typing import Any, Optional, Union, Dict, Tuple, Iterable
-from gossipy.data import DataDispatcher
+from .data import DataDispatcher
 
 from . import CACHE, LOG
 from .core import AntiEntropyProtocol, CreateModelMode, MessageType, Message, P2PNetwork


### PR DESCRIPTION
Allow to call the library from an external folder, replace absolute path with relative paths. 