### PR TITLE
set_seed in main files are not effective after a certain point

### DIFF
--- a/gossipy/data/__init__.py
+++ b/gossipy/data/__init__.py
@@ -15,6 +15,7 @@ from torch import Tensor, tensor
 from sklearn import datasets
 from sklearn.datasets import load_svmlight_file
 from sklearn.preprocessing import StandardScaler, LabelEncoder
+import random
 
 from .. import LOG
 from ..utils import download_and_unzip, download_and_untar
@@ -166,6 +167,7 @@ class AssignmentHandler():
     def __init__(self, seed: int):
         torch.manual_seed(seed)
         np.random.seed(seed)
+        random.seed(seed)
     
     def uniform(self,
                 y: Union[np.ndarray, torch.Tensor],
@@ -378,7 +380,8 @@ class DataDispatcher():
                  data_handler: DataHandler,
                  n: int=0, #number of clients
                  eval_on_user: bool=True,
-                 auto_assign: bool=True):
+                 auto_assign: bool=True,
+                 seed: int = 42):
         """DataDispatcher is responsible for assigning data to clients.
 
         The assignment is done by shuffling the data and assigning it uniformly to the clients.
@@ -405,7 +408,7 @@ class DataDispatcher():
         self.tr_assignments = None
         self.te_assignments = None
         if auto_assign:
-            self.assign()
+            self.assign(seed)
     
     def set_assignments(self, tr_assignments: List[int],
                               te_assignments: Optional[List[int]]) -> None:


### PR DESCRIPTION
Hello,
The class *DataDispatcher* (more particularly *AssignmentHandler*) set the random seed of numpy.random and pytorch to 42.
In a main file, gossipy's *set_seed* function is used before the initialization of a *DataDispatcher* object, the effective seed will always be 42. Thus erasing the effect of *set_seed*. 
The direct consequence of that: each simulation (even with different random seed set used in *set_seed*) is the same as the randomness depends on the most recent seed set which is hardcoded to 42.

Prior to this commit, when initializing a *DataDispatcher* object, a seed was not needed. This commit adds *seed* as a parameter set to 42 by default and used when calling its *assign* method.
Hence, it will keep the old behavior when no seed are set.
When an integer is generated randomly after a *set_seed* call and used to initialize a *DataDispatcher* object, simulations are now different if *set_seed* is called with different values.

Additionally, python's random library is also initialized with the seed given in argument to the *assign* method.

I remarked that *RecSysDataDispatcher* also have the same problem.
